### PR TITLE
Make android sdk stuff executable for everyone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update -y && \
     # Installs Android SDK
     curl -sL ${ANDROID_SDK_URL} | tar xz -C . && \
     echo y | android update sdk -a -u -t platform-tools,${ANDROID_APIS},build-tools-${ANDROID_BUILD_TOOLS_VERSION} && \
+    chmod a+x -R $ANDROID_HOME && \
 
     # Clean up
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \


### PR DESCRIPTION
We use this image to build applications, but for a number of reasons our image runs as a different user.

The executables in /opt/android-sdk-linux/ have owner and group executable bit set, but their owner is an arbitrary uid, and the group is invalid too.

In order to quickly fix this, we run the chmod in the image that inherits from yours, duplicating all the files changed in a top layer. 