### PR TITLE
chore: update Android SDK tools to version 35 and adjust README for API levels 31-35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM beevelop/java
 
 # https://developer.android.com/studio/#downloads
-ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/commandlinetools-linux-10406996_latest.zip" \
-    ANDROID_BUILD_TOOLS_VERSION=34.0.0 \
+ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip" \
+    ANDROID_BUILD_TOOLS_VERSION=35.0.0 \
     ANT_HOME="/usr/share/ant" \
     MAVEN_HOME="/usr/share/maven" \
     GRADLE_HOME="/usr/share/gradle" \
     ANDROID_SDK_ROOT="/opt/android" \
     ANDROID_HOME="/opt/android"
 
-ENV PATH $PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/build-tools/$ANDROID_BUILD_TOOLS_VERSION:$ANT_HOME/bin:$MAVEN_HOME/bin:$GRADLE_HOME/bin
+ENV PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/build-tools/$ANDROID_BUILD_TOOLS_VERSION:$ANT_HOME/bin:$MAVEN_HOME/bin:$GRADLE_HOME/bin
 
 WORKDIR /opt
 
@@ -26,8 +26,8 @@ RUN mkdir android && cd android && \
 
 RUN mkdir /root/.android && touch /root/.android/repositories.cfg && \
     while true; do echo 'y'; sleep 2; done | sdkmanager "platform-tools" "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" && \
-    while true; do echo 'y'; sleep 2; done | sdkmanager "platforms;android-28" "platforms;android-29" "platforms;android-30" && \
-    while true; do echo 'y'; sleep 2; done | sdkmanager "platforms;android-31" "platforms;android-32" "platforms;android-33" "platforms;android-34" && \
+    while true; do echo 'y'; sleep 2; done | sdkmanager "platforms;android-31" "platforms;android-32" "platforms;android-33" && \
+    while true; do echo 'y'; sleep 2; done | sdkmanager "platforms;android-34" "platforms;android-35" && \
     while true; do echo 'y'; sleep 2; done | sdkmanager "extras;android;m2repository" "extras;google;google_play_services" "extras;google;instantapps" "extras;google;m2repository" &&  \
     while true; do echo 'y'; sleep 2; done | sdkmanager "add-ons;addon-google_apis-google-22" "add-ons;addon-google_apis-google-23" "add-ons;addon-google_apis-google-24" "skiaparser;1" "skiaparser;2" "skiaparser;3"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ ENV PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/plat
 
 WORKDIR /opt
 
-RUN apt-get -qq update && \
-    apt-get -qq install -y wget curl maven ant unzip
+RUN apt -qq update && \
+    apt -qq install -y --no-install-recommends wget curl maven ant unzip && \
+    apt autoremove -y && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Installs gradle
 RUN wget https://services.gradle.org/distributions/gradle-8.12-bin.zip && \
@@ -27,8 +30,8 @@ RUN mkdir android && cd android && \
     wget -O tools.zip ${ANDROID_SDK_URL} && \
     unzip tools.zip && rm tools.zip && \
     cd cmdline-tools && \
-    mkdir latest && \
-    ls | grep -v latest | xargs mv -t latest
+    mkdir -p latest && \
+    find . -mindepth 1 -maxdepth 1 ! -name latest -exec mv -t latest {} +
 
 RUN mkdir /root/.android && touch /root/.android/repositories.cfg && \
     while true; do echo 'y'; sleep 2; done | sdkmanager "platform-tools" "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" && \
@@ -40,7 +43,5 @@ RUN mkdir /root/.android && touch /root/.android/repositories.cfg && \
 RUN chmod a+x -R $ANDROID_SDK_ROOT && \
     chown -R root:root $ANDROID_SDK_ROOT && \
     rm -rf /opt/android/licenses && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    apt-get autoremove -y && \
-    apt-get clean && \
+    rm -rf /tmp/* /var/tmp/* && \
     mvn -v && gradle -v && java -version && ant -version

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,13 @@ ENV PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/plat
 WORKDIR /opt
 
 RUN apt-get -qq update && \
-    apt-get -qq install -y wget curl maven ant gradle
+    apt-get -qq install -y wget curl maven ant unzip
+
+# Installs gradle
+RUN wget https://services.gradle.org/distributions/gradle-8.12-bin.zip && \
+    unzip -d /usr/share/ gradle-8.12-bin.zip && \
+    mv /usr/share/gradle-8.12 /usr/share/gradle && \
+    ln -s /usr/share/gradle/bin/gradle /usr/bin/gradle
 
 # Installs Android SDK
 RUN mkdir android && cd android && \

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 ![CalVer](https://img.shields.io/badge/CalVer-YYYY.MM.MICRO-22bfda.svg?style=for-the-badge)
 [![Beevelop](https://img.shields.io/badge/-%20Made%20with%20%F0%9F%8D%AF%20by%20%F0%9F%90%9Dvelop-blue.svg?style=for-the-badge)](https://beevelop.com)
 
-# Android 13 (API levels 28 - 34)
+# Android 15 (API levels 31 - 35)
 
 ## based on [beevelop/java](https://github.com/beevelop/docker-java)
 
-- Java `17.0.9`
+- Java `17.0.12`
 - Gradle `4.4.1` (Groovy: `2.4.21`)
 - Apache Maven `3.6.3`
 - Ant `1.10.12`
@@ -41,7 +41,7 @@ RUN yes | sdkmanager --licenses --sdk_root=$ANDROID_SDK_ROOT
 
 ## Licenses
 
-The usage of the Android SDK requires you to accept the licenses 
+The usage of the Android SDK requires you to accept the licenses
 
 ## Maintenance
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## based on [beevelop/java](https://github.com/beevelop/docker-java)
 
 - Java `17.0.12`
-- Gradle `4.4.1` (Groovy: `2.4.21`)
+- Gradle `8.12` (Groovy: `3.0.22`)
 - Apache Maven `3.6.3`
 - Ant `1.10.12`
 


### PR DESCRIPTION
I use [docker-cordova](https://github.com/beevelop/docker-cordova) to build android apps. I need to update that to cordova 14, which uses SDK Platform 35 and SDK Build Tools 35.0.0.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Android 15 and API levels 31–35.
  - Included Gradle 8.12 in the build environment.

- Chores
  - Upgraded Android command-line tools and build tools to the latest versions.
  - Streamlined package installation and cleanup for smaller, more reliable images.
  - Improved PATH and SDK installation flow for more robust builds.

- Documentation
  - Updated supported Android versions, Java version, and Gradle details in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->